### PR TITLE
Add AbstractFluentBuilder#bind(BeanPropertySqlParameterSource)

### DIFF
--- a/src/main/java/com/clevergang/jdbc/fluent/AbstractFluentBuilder.java
+++ b/src/main/java/com/clevergang/jdbc/fluent/AbstractFluentBuilder.java
@@ -16,16 +16,20 @@
 
 package com.clevergang.jdbc.fluent;
 
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 /**
  * Abstract class aggregating what all fluent builders have in common.
  *
  * @author Bretislav Wajtr
+ * @author S.Kashihara
  */
 abstract class AbstractFluentBuilder<T> {
 
     private MapSqlParameterSource mapParameterSource;
+    private BeanPropertySqlParameterSource beanParameterSource;
 
     /**
      * Bind a parameter of this query/statement builder.
@@ -36,19 +40,47 @@ abstract class AbstractFluentBuilder<T> {
      */
     @SuppressWarnings("unchecked")
     public T bind(String parameterName, Object parameterValue) {
-        getBoundParameters().addValue(parameterName, parameterValue);
+    	if (beanParameterSource != null) {
+    		throw new UnsupportedOperationException("Cannot set both bind(Object object) and bind(String parameterName, Object parameterValue).");
+    	}
+    	getMapBoundParameters().addValue(parameterName, parameterValue);
         return (T) this;
+    }
+
+    /**
+     * Bind a parameter object of this query/statement builder.
+     * @param object the object of the parameter
+     * @return a reference to the same query/statement builder,
+     * so it's possible to chain several calls together
+     */
+    @SuppressWarnings("unchecked")
+    public T bind(Object object) {
+    	if (mapParameterSource != null) {
+    		throw new UnsupportedOperationException("Cannot set both bind(Object object) and bind(String parameterName, Object parameterValue).");
+    	}
+    	beanParameterSource = new BeanPropertySqlParameterSource(object);
+        return (T) this;
+    }
+
+    /**
+     * @return Returns a SqlParameterSource representing parameters which were already bound to this query/statement builder.
+     * If no parameters were bound, then empty SqlParameterSource will be returned.
+     */
+    public SqlParameterSource getBoundParameters() {
+    	if (beanParameterSource != null) {
+    		return beanParameterSource;
+    	}
+    	return getMapBoundParameters();
     }
 
     /**
      * @return Returns a MapSqlParameterSource representing parameters which were already bound to this query/statement builder.
      * If no parameters were bound, then empty MapSqlParameterSource will be returned.
      */
-    public MapSqlParameterSource getBoundParameters() {
+    public MapSqlParameterSource getMapBoundParameters() {
         if (mapParameterSource == null) {
             mapParameterSource = new MapSqlParameterSource();
         }
-
         return mapParameterSource;
     }
 

--- a/src/test/java/com/clevergang/jdbc/tests/fluent/query/FluentQueryBindingTest.java
+++ b/src/test/java/com/clevergang/jdbc/tests/fluent/query/FluentQueryBindingTest.java
@@ -16,28 +16,31 @@
 
 package com.clevergang.jdbc.tests.fluent.query;
 
-import com.clevergang.jdbc.FluentNamedParameterJdbcTemplate;
-import com.clevergang.jdbc.fluent.FluentQueryBuilder;
-import com.clevergang.jdbc.tests.TestSpringContext;
+import static org.hamcrest.CoreMatchers.*;
+
+import java.time.Instant;
+import java.util.Date;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-import java.util.Date;
-
-import static org.hamcrest.CoreMatchers.equalTo;
+import com.clevergang.jdbc.FluentNamedParameterJdbcTemplate;
+import com.clevergang.jdbc.fluent.FluentQueryBuilder;
+import com.clevergang.jdbc.tests.TestSpringContext;
 
 /**
  * The very basic tests of FluentQueryBuilder - testing of the various forms of .bind() method
  *
  * @author Bretislav Wajtr
+ * @author S.Kashihara
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {TestSpringContext.class})
@@ -131,7 +134,127 @@ public class FluentQueryBindingTest {
         FluentQueryBuilder builder = jdbc.query("SELECT name FROM users WHERE id = :id")
                 .bind("id", 1);
 
-        builder.getBoundParameters().addValue("id", 2);
+        builder.getMapBoundParameters().addValue("id", 2);
+        String name = builder.fetchOne(String.class);
+
+        Assert.assertThat(name, equalTo("alex"));
+    }
+
+    
+	@SuppressWarnings("unused")
+    private static class TestParameterBean {
+    	public int id;
+    	public int id1;
+    	public int id2;
+    	public String nameTemplate;
+    	public Date maxDate;
+		public int getId() {
+			return id;
+		}
+		public int getId1() {
+			return id1;
+		}
+		public int getId2() {
+			return id2;
+		}
+		public String getNameTemplate() {
+			return nameTemplate;
+		}
+		public Date getMaxDate() {
+			return maxDate;
+		}
+    }
+    
+    @Test
+    public void testBindBeanSingleNumberParameter() {
+        // original code
+        String query = "SELECT name FROM users WHERE id = :id";
+        TestParameterBean bean = new TestParameterBean();
+        bean.id = 1;
+        BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(bean);
+        String userName = jdbc.queryForObject(query, params, String.class);
+
+        Assert.assertThat(userName, equalTo("mkyong"));
+
+        // fluent code
+        String userName2 = jdbc.query("SELECT name FROM users WHERE id = :id")
+                .bind(bean)
+                .fetchOne(String.class);
+
+        Assert.assertThat(userName2, equalTo("mkyong"));
+    }
+
+    @Test
+    public void testBindBeanTwoNumberParameters() {
+        // original code
+        String query = "SELECT name FROM users WHERE id > :id1 AND id < :id2";
+        TestParameterBean bean = new TestParameterBean();
+        bean.id1 = 1;
+        bean.id2 = 3;
+        BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(bean);
+        String userName = jdbc.queryForObject(query, params, String.class);
+
+        Assert.assertThat(userName, equalTo("alex"));
+
+        // fluent code
+        String userName2 = jdbc.query("SELECT name FROM users WHERE id > :id1 AND id < :id2")
+                .bind("id1", 1)
+                .bind("id2", 3)
+                .fetchOne(String.class);
+
+        Assert.assertThat(userName2, equalTo("alex"));
+    }
+
+    @Test
+    public void testBindBeanTwoNumberAndOneStringParameters() {
+        // original code
+        String query = "SELECT name FROM users WHERE id > :id1 AND id < :id2 AND name LIKE :nameTemplate";
+        TestParameterBean bean = new TestParameterBean();
+        bean.id1 = 1;
+        bean.id2 = 3;
+        bean.nameTemplate = "a%";
+        BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(bean);
+        String userName = jdbc.queryForObject(query, params, String.class);
+
+        Assert.assertThat(userName, equalTo("alex"));
+
+        // fluent code
+        String userName2 = jdbc.query("SELECT name FROM users WHERE id > :id1 AND id < :id2 AND name LIKE :nameTemplate")
+                .bind("id1", 1)
+                .bind("id2", 3)
+                .bind("nameTemplate", "a%")
+                .fetchOne(String.class);
+
+        Assert.assertThat(userName2, equalTo("alex"));
+    }
+
+    @Test
+    public void testBindBeanDateParameter() {
+        // original code
+        String query = "SELECT name FROM users WHERE BIRTH_DATE < :maxDate";
+        TestParameterBean bean = new TestParameterBean();
+        bean.maxDate = Date.from(Instant.parse("1981-01-01T00:00:00.00Z"));
+        BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(bean);
+        String userName = jdbc.queryForObject(query, params, String.class);
+
+        Assert.assertThat(userName, equalTo("mkyong"));
+
+        // fluent code
+        String userName2 = jdbc.query("SELECT name FROM users WHERE BIRTH_DATE < :maxDate")
+                .bind("maxDate", Date.from(Instant.parse("1981-01-01T00:00:00.00Z")))
+                .fetchOne(String.class);
+
+        Assert.assertThat(userName2, equalTo("mkyong"));
+    }
+
+    @Test
+    public void testModifyBeanBoundParameter() {
+        TestParameterBean bean = new TestParameterBean();
+        bean.id = 1;
+        FluentQueryBuilder builder = jdbc.query("SELECT name FROM users WHERE id = :id")
+                .bind(bean);
+
+        bean.id = 2;
         String name = builder.fetchOne(String.class);
 
         Assert.assertThat(name, equalTo("alex"));


### PR DESCRIPTION
Added the ability to bind bean.
JUnit tests was also added.

```java
// fluent code === original ===
String userName2 = jdbc.query("SELECT name FROM users WHERE id = :id")
		.bind("id", 1)
		.fetchOne(String.class);

Assert.assertThat(userName2, equalTo("mkyong"));

// fluent code === NEW ===
TestParameterBean bean = new TestParameterBean();
bean.id = 1;
String userName2 = jdbc.query("SELECT name FROM users WHERE id = :id")
		.bind(bean) // <<<<<<<<<<<<<
		.fetchOne(String.class);

Assert.assertThat(userName2, equalTo("mkyong"));
```